### PR TITLE
Add QtPy to install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'markdown',
+        'QtPy'
     ],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Adding QtPy to install_requires in setup.py would be useful to resolve library dependencies without having to manually install qtpy for users installing this library.